### PR TITLE
📃 docs: 修复README中失效的Star历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,4 +352,4 @@ This project is licensed under the terms in [LICENSE](LICENSE).
 
 ---
 
-[![Star History Chart](https://api.star-history.com/svg?repos=opsre/LiteOps&type=Date)](https://www.star-history.com/#opsre/LiteOps&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=opsre/LiteOps&type=Date)](https://star-history.dera.page/#opsre/LiteOps&Date)


### PR DESCRIPTION
README中的Star历史图表当前已无法正常加载，原因是GitHub的API限制导致原有数据源不可用。本次调整将图表地址更新为可正常工作的新域名，使Star历史图表恢复显示。